### PR TITLE
Allow user to reorder mapping items

### DIFF
--- a/css/import/import.css
+++ b/css/import/import.css
@@ -201,6 +201,16 @@
     margin: 0;
   }
 
+  /* Show 'up' button, or color swatch. */
+  & .row:first-child .move-up {
+    display: none;
+  }
+
+  & .row:not(:first-child) .sec-color {
+    display: none;
+    visibility: collapse;
+  }
+
   & .row {
     padding: 1rem;
     display: flex;
@@ -213,12 +223,14 @@
       min-width: 200px;
       height: 1rem;
       border: none;
+      font-weight: bold;
     }
 
     & #sec-color {
-      min-width: 50px;
+      min-width: 72px;
       height: 1rem;
       border: none;
+      border-radius: 8px;
     }
 
     & #sec-layout {

--- a/js/sections-mapping/sections-mapping.import.js
+++ b/js/sections-mapping/sections-mapping.import.js
@@ -4,6 +4,7 @@
 
 import * as parsers from './parsers/parsers.js';
 import { getImporterSectionsMapping } from './utils.ui.js';
+import { getElementByXpath } from '../shared/utils.js';
 
 /**
  * functions
@@ -19,10 +20,6 @@ export function generateDocumentPath({ document, url }) {
     .replace(/\.html$/, '')
     .replace(/[^a-z0-9/]/gm, '-');
   return WebImporter.FileUtils.sanitizePath(p);
-}
-
-function getElementByXpath(document, path) {
-  return document.evaluate(path, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
 }
 
 /**

--- a/js/shared/utils.js
+++ b/js/shared/utils.js
@@ -6,16 +6,43 @@ async function asyncForEach(array, callback) {
 }
 
 function getElementByXpath(document, path) {
-  return document.evaluate(
-    path,
-    document,
-    null,
-    XPathResult.FIRST_ORDERED_NODE_TYPE,
-    null,
-  ).singleNodeValue;
+  try {
+    return document.evaluate(
+      path,
+      document,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+      null,
+    ).singleNodeValue;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log('Error evaluating this xpath:', path, e);
+  }
+  return undefined;
+}
+
+// Create and return an element with optional 'props' attributes and optional inner text.
+function createElement(nodeName, props, innerText) {
+  const newElement = document.createElement(nodeName);
+  if (newElement) {
+    if (props) {
+      Object.entries(props)
+        .forEach(([key, value]) => {
+          newElement.setAttribute(key, value);
+        });
+    }
+    if (innerText) {
+      newElement.innerText = innerText;
+    }
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('Error creating element:', nodeName);
+  }
+  return newElement;
 }
 
 export {
   asyncForEach,
   getElementByXpath,
+  createElement,
 };

--- a/modules/swc.js
+++ b/modules/swc.js
@@ -42,3 +42,4 @@ import '@spectrum-web-components/progress-circle/sp-progress-circle.js';
 
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-delete.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-arrow-up.js';


### PR DESCRIPTION
## Description
Once an box/item is in the mapping, allow it to be reordered so the user does not have to add them in an exact order.

## Related Issue
**This PR was created on the PR to save more than 1 site in the mapping (local-storage): https://github.com/adobe/helix-importer-ui/pull/354  That should be merged first.**

## Motivation and Context
Through testing, especially with a complex page, I found I often would want to add a box later and found that deleting a bunch of mappings, adding the one I required, and then adding all the others back again was tedious.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
The **caret (^) will be replaced by a Spectrum 'up arrow'** after it is built.  I didn't want to change anything under `js/dist` (see smaller screenshot below)
![image](https://github.com/adobe/helix-importer-ui/assets/7156029/d11f7ec4-4b8a-4de2-87e5-8bd8e101df7c)
![image](https://github.com/adobe/helix-importer-ui/assets/7156029/590ed5c4-3086-4bc6-ba17-1f046c34f8d9)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.