### PR TITLE
Little UI/Experience touches 

### DIFF
--- a/import-express.html
+++ b/import-express.html
@@ -75,6 +75,9 @@
                                         <sp-checkbox class="option-field" id="import-scroll-to-bottom" checked>
                                             Scroll to bottom
                                         </sp-checkbox>
+                                        <sp-checkbox class="option-field" id="import-detect-on-load" checked>
+                                            Detect Sections when page loads
+                                        </sp-checkbox>
 
                                         <sp-field-label for="import-custom-headers">Custom headers</sp-field-label>
                                         <sp-textfield class="option-field" id="import-custom-headers" multiline placeholder="Define your custom headers as a JSON object with key/value (header name/header value)"></sp-textfield>
@@ -149,7 +152,7 @@
                             <sp-tab-panel value="import-transform">
                                 <div data-panel="source">
                                     <div class="code">
-                                        <textarea id="import-transform-source" rows="4" cols="10"></textarea>
+                                        <textarea aria-label="Transform Source" id="import-transform-source" rows="4" cols="10"></textarea>
                                     </div>
                                 </div>
                             </sp-tab-panel>

--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -114,9 +114,9 @@ const loadResult = ({ md, html: outputHTML }, originalURL) => {
     ui.markdownEditor?.setValue(md || '');
 
     if (ui.markdownPreview) {
-      const mdPreview = WebImporter.md2html(md);
-      // XSS review: we need interpreted HTML here - <script> tags are removed by importer anyway
-      ui.markdownPreview.innerHTML = mdPreview;
+      // XSS review: we need interpreted HTML (from md2html) here
+      // - <script> tags are removed by importer anyway
+      ui.markdownPreview.innerHTML = WebImporter.md2html(md);
       // remove existing classes and styles
       Array.from(ui.markdownPreview.querySelectorAll('[class], [style]')).forEach((t) => {
         t.removeAttribute('class');
@@ -1191,6 +1191,10 @@ const init = () => {
 
   if (!IS_BULK) setupUI();
   attachListeners();
+
+  if (IS_EXPRESS && config.fields['import-detect-on-load'] && config.fields['import-url']) {
+    DETECT_BUTTON?.click();
+  }
 };
 
 init();

--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -28,6 +28,7 @@ const PREVIEW_CONTAINER = document.querySelector(`${PARENT_SELECTOR} .page-previ
 
 const IMPORTFILEURL_FIELD = document.getElementById('import-file-url');
 const IMPORT_BUTTON = document.getElementById('import-doimport-button');
+const IMPORT_URL_FIELD = document.getElementById('import-url');
 
 // const SAVEASWORD_BUTTON = document.getElementById('saveAsWord');
 const FOLDERNAME_SPAN = document.getElementById('folder-name');
@@ -1168,6 +1169,12 @@ const attachListeners = () => {
     const importURL = config.fields['import-url'];
     if (importURL && importURL.length > 0) {
       window.open(importURL, '_blank');
+    }
+  });
+
+  IMPORT_URL_FIELD?.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter' && IS_EXPRESS && config.fields['import-url']) {
+      DETECT_BUTTON?.click();
     }
   });
 

--- a/js/import/util/metadata.js
+++ b/js/import/util/metadata.js
@@ -145,15 +145,21 @@ const initializeMetadata = (importURL, getRowDeleteButton) => {
 
   // Display existing metadata values
   const metadataMappings = mappingData.filter((md) => md.mapping === 'metadata');
-  if (metadataMappings.length === 0) {
-    // If no rows, add one to lead the user.
-    ADD_METADATA_BUTTON.click();
-  } else {
+  if (metadataMappings.length > 0) {
     metadataMappings.forEach((metadata) => {
       const row = getMetadataRow(importURL, metadata);
       METADATA_EDITOR_SECTIONS.appendChild(row);
     });
   }
+
+  // Add a blank row when activated - ensure a blank one doesn't already exist.
+  document.querySelector('[value="block-customization"]').addEventListener('click', () => {
+    const textFields = [...METADATA_EDITOR.querySelectorAll('.row:not(.header) sp-textfield')];
+    if (textFields.length === 0) {
+      // If no rows, add one to lead the user after UI resets.
+      ADD_METADATA_BUTTON.click();
+    }
+  });
 };
 
 export {

--- a/js/sections-mapping/sections-mapping.import.js
+++ b/js/sections-mapping/sections-mapping.import.js
@@ -52,7 +52,10 @@ export default {
         keyCode: 27,
       }),
     );
-    document.elementFromPoint(0, 0).click();
+    const topLeft = document.elementFromPoint(0, 0);
+    if (topLeft) {
+      topLeft.click();
+    }
 
     // mark hidden divs + add bounding client rect data to all "visible" divs
     document.querySelectorAll('div').forEach((div) => {
@@ -152,13 +155,11 @@ export default {
     // // make every report value a string
     // Object.keys(IMPORT_REPORT).map(k => (IMPORT_REPORT[k] = '' + IMPORT_REPORT[k]));
 
-    const elements = [{
+    return [{
       element: importedContent,
       path: generateDocumentPath({ document, url: params.originalURL }),
       report: IMPORT_REPORT,
     }];
-
-    return elements;
   },
 
   /**

--- a/js/shared/alert.js
+++ b/js/shared/alert.js
@@ -5,7 +5,11 @@ const doAlert = (message, variant) => {
   toast.setAttribute('timeout', 1);
   toast.setAttribute('variant', variant);
   toast.setAttribute('open', true);
-  toast.textContent = message;
+  if (message.includes('http://localhost:')) {
+    toast.textContent = decodeURIComponent(message.replace(/http(.*?)host=/, ''));
+  } else {
+    toast.textContent = message;
+  }
   toast.addEventListener('close', () => {
     toast.remove();
   });


### PR DESCRIPTION
Little Usability things:
- only add blank metadata row if one isn't already there (gave an error on repeats)
- `Detect Sections` right away on load, with option to turn it off (In Express, with `import-url` set).
- Detect Sections on 'enter' key in URL field
- Do not display ugly URL in alert's  (localhost.... escaped real url -> ugly)

![image](https://github.com/arumsey/helix-importer-ui/assets/7156029/4d35d08b-1e4b-4589-8530-ce6b978d06fe)
